### PR TITLE
Add stream duplicator component

### DIFF
--- a/src/main/tydi_lib/TydiLib.scala
+++ b/src/main/tydi_lib/TydiLib.scala
@@ -402,6 +402,12 @@ class PhysicalStream(private val e: TydiEl, n: Int = 1, d: Int = 0, c: Int, priv
     processingModule.in := this
     processingModule.out
   }
+
+  def duplicate(k: Int)(implicit parentModule: TydiModule): Vec[PhysicalStream] = {
+    val processingModule = parentModule.Module(new StreamDuplicator(k, this))
+    processingModule.in := this
+    processingModule.out
+  }
 }
 
 object PhysicalStream {


### PR DESCRIPTION
This component duplicates an incoming stream to `k` outgoing streams. A chaining method is also included as syntax sugar.