### PR TITLE
Add support for 0-bit logic types

### DIFF
--- a/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -380,8 +380,16 @@ class PhysicalStream(private val e: TydiEl, n: Int = 1, d: Int = 0, c: Int, priv
     this.last    := bundle.last.asUInt
     this.valid   := bundle.valid
     bundle.ready := this.ready
-    this.data    := bundle.getDataConcat
-    this.user    := bundle.getUserConcat
+    if (elWidth > 0) {
+      this.data := bundle.getDataConcat
+    } else {
+      this.data := DontCare
+    }
+    if (userElWidth > 0) {
+      this.user := bundle.getUserConcat
+    } else {
+      this.user := DontCare
+    }
   }
 
   def :=(bundle: PhysicalStream): Unit = {

--- a/src/main/scala/nl/tudelft/tydi_chisel/examples/timestamped_message/TimestampedMessage.scala
+++ b/src/main/scala/nl/tudelft/tydi_chisel/examples/timestamped_message/TimestampedMessage.scala
@@ -54,18 +54,18 @@ class TimestampedMessageModuleOut extends TydiModule {
   //   We have 1 lane in this case
 
   // Top stream
-  stream.valid := true.B
-  stream.strb  := 1.U
-  stream.stai  := 0.U
-  stream.endi  := 1.U
-  stream.last  := 0.U
+  stream.valid   := true.B
+  stream.strb    := 1.U
+  stream.stai    := 0.U
+  stream.endi    := 1.U
+  stream.last(0) := 0.U
 
   // Child stream
   stream.el.message.valid := true.B
   stream.el.message.strb  := 1.U
   stream.el.message.stai  := 0.U
   stream.el.message.endi  := 1.U
-  stream.el.message.last  := 0.U
+  stream.el.message.last.foreach(_ := 0.U)
 }
 
 class TimestampedMessageModuleIn extends TydiModule {


### PR DESCRIPTION
This can happen when the direct child structure e.g. only consists of sub-streams.
Fix `EmptyReduceLeft` error that one would otherwise get. This is only a problem for connecting detailed streams to basic streams.