### PR TITLE
Chisel 6 update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val chiselVersion = "5.1.0"
+val chiselVersion = "6.3.0"
 
 ThisBuild / scalaVersion := "2.13.12"
 
@@ -25,7 +25,7 @@ lazy val library: Project = (project in file("library"))
     commonSettings,
     name                                     := "Tydi-Chisel",
     description                              := "Tydi-Chisel is an implementation of Tydi concepts in the Chisel HDL.",
-    libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "5.0.2" % Test
+    libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "6.0.0" % Test
   )
 //  .dependsOn(testingTools % "test->test")
 
@@ -34,7 +34,7 @@ lazy val testingTools: Project = (project in file("testing"))
     commonSettings,
     name                                     := "Tydi-Chisel-Test",
     description                              := "This package contains the testing tools for Tydi-Chisel",
-    libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "5.0.2"
+    libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "6.0.0"
   )
   .dependsOn(library % "compile->compile") // Make testingTools project depend on the library project
 

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -5,7 +5,6 @@ import scala.collection.mutable.ListBuffer
 
 import chisel3._
 import chisel3.experimental.{BaseModule, ExtModule}
-import chisel3.internal.firrtl.Width
 import chisel3.util.{log2Ceil, Cat}
 import nl.tudelft.tydi_chisel.ReverseTranspiler._
 import nl.tudelft.tydi_chisel.utils.ComplexityConverter

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/examples/pipeline/PipelineExample.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/examples/pipeline/PipelineExample.scala
@@ -1,7 +1,6 @@
 package nl.tudelft.tydi_chisel.examples.pipeline
 
 import chisel3._
-import chisel3.internal.firrtl.Width
 import chisel3.util.Counter
 import circt.stage.ChiselStage.{emitCHIRRTL, emitSystemVerilog}
 import nl.tudelft.tydi_chisel._

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/examples/rgb/Rgb.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/examples/rgb/Rgb.scala
@@ -1,7 +1,6 @@
 package nl.tudelft.tydi_chisel.examples.rgb
 
 import chisel3._
-import chisel3.internal.firrtl.Width
 import circt.stage.ChiselStage.{emitCHIRRTL, emitSystemVerilog}
 import nl.tudelft.tydi_chisel._
 

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/examples/timestamped_message/TimestampedMessage.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/examples/timestamped_message/TimestampedMessage.scala
@@ -1,7 +1,6 @@
 package nl.tudelft.tydi_chisel.examples.timestamped_message
 
 import chisel3._
-import chisel3.internal.firrtl.Width
 import circt.stage.ChiselStage.{emitCHIRRTL, emitSystemVerilog}
 import nl.tudelft.tydi_chisel._
 

--- a/library/src/test/scala/gcd/GCDSpec.scala
+++ b/library/src/test/scala/gcd/GCDSpec.scala
@@ -23,9 +23,7 @@ class GCDSpec extends AnyFreeSpec with ChiselScalatestTester {
   "Gcd should calculate proper greatest common denominator" in {
     test(new DecoupledGcd(16)) { dut =>
       dut.input.initSource()
-      dut.input.setSourceClock(dut.clock)
       dut.output.initSink()
-      dut.output.setSinkClock(dut.clock)
 
       val testValues = for { x <- 0 to 10; y <- 0 to 10 } yield (x, y)
       val inputSeq   = testValues.map { case (x, y) => (new GcdInputBundle(16)).Lit(_.value1 -> x.U, _.value2 -> y.U) }

--- a/testing/src/main/scala/nl/tudelft/tydi_chisel_test/TydiTesting.scala
+++ b/testing/src/main/scala/nl/tudelft/tydi_chisel_test/TydiTesting.scala
@@ -1,6 +1,7 @@
 package nl.tudelft.tydi_chisel_test
 
 import scala.language.implicitConversions
+
 import chisel3._
 import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 import chisel3.experimental.VecLiterals.{AddObjectLiteralConstructor, AddVecLiteralConstructor}
@@ -45,14 +46,14 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
   }
 
   private def _enqueueNow(
-                          data: Option[Vec[Tel]],
-                          last: Option[Vec[UInt]] = None,
-                          strb: Option[UInt] = None,
-                          stai: Option[UInt] = None,
-                          endi: Option[UInt] = None,
-                          run: => Unit = {},
-                          reset: Boolean = false
-                        ): Unit = {
+    data: Option[Vec[Tel]],
+    last: Option[Vec[UInt]] = None,
+    strb: Option[UInt] = None,
+    stai: Option[UInt] = None,
+    endi: Option[UInt] = None,
+    run: => Unit = {},
+    reset: Boolean = false
+  ): Unit = {
     if (data.isDefined) {
       x.data.pokePartial(data.get)
     }
@@ -162,9 +163,9 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
   }
 
   @deprecated("You no longer need to set the clock explicitly.", since = "6.0.x")
-  protected val decoupledSourceKey = new Object()
+  protected val decoupledSourceKey            = new Object()
   def setSourceClock(clock: Clock): this.type = this
-  protected val decoupledSinkKey = new Object()
+  protected val decoupledSinkKey              = new Object()
   @deprecated("You no longer need to set the clock explicitly.", since = "6.0.x")
   def setSinkClock(clock: Clock): this.type = this
 
@@ -193,13 +194,13 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
   }
 
   private def _expectDequeueNow(
-                        data: Option[Tel],
-                        last: Option[Vec[UInt]] = None,
-                        strb: Option[UInt] = None,
-                        stai: Option[UInt] = None,
-                        endi: Option[UInt] = None,
-                        run: => Unit = {}
-                      ): Unit = {
+    data: Option[Tel],
+    last: Option[Vec[UInt]] = None,
+    strb: Option[UInt] = None,
+    stai: Option[UInt] = None,
+    endi: Option[UInt] = None,
+    run: => Unit = {}
+  ): Unit = {
     x.ready.poke(true)
     fork
       .withRegion(Monitor) {
@@ -287,7 +288,9 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
     val streamAntiDir                      = if (x.r) out else in
 
     try
-      stringBuilder.append(s"State of \"${x.instanceName}\" $streamDir @ clk-step ${x.getSourceClock().getStepCount}:\n")
+      stringBuilder.append(
+        s"State of \"${x.instanceName}\" $streamDir @ clk-step ${x.getSourceClock().getStepCount}:\n"
+      )
     catch {
       case e: ClockResolutionException =>
         stringBuilder.append(s"State of \"${x.instanceName}\" $streamDir (unable to get clock):\n")

--- a/testing/src/main/scala/nl/tudelft/tydi_chisel_test/TydiTesting.scala
+++ b/testing/src/main/scala/nl/tudelft/tydi_chisel_test/TydiTesting.scala
@@ -48,7 +48,8 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
     last: Option[UInt] = None,
     strb: Option[UInt] = None,
     stai: Option[UInt] = None,
-    endi: Option[UInt] = None
+    endi: Option[UInt] = None,
+    run: => Unit = {}
   ): Unit = {
     x.el.poke(data)
     if (last.isDefined) {
@@ -65,6 +66,7 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
       x.endi.poke(endi.get)
     }
     x.valid.poke(true)
+    run
     fork
       .withRegion(Monitor) {
         x.ready.expect(true)
@@ -78,7 +80,8 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
     last: Option[Vec[UInt]] = None,
     strb: Option[UInt] = None,
     stai: Option[UInt] = None,
-    endi: Option[UInt] = None
+    endi: Option[UInt] = None,
+    run: => Unit = {}
   ): Unit = {
     x.data.pokePartial(data)
     if (last.isDefined) {
@@ -94,6 +97,7 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
       x.endi.poke(endi.get)
     }
     x.valid.poke(true)
+    run
     fork
       .withRegion(Monitor) {
         x.ready.expect(true)
@@ -107,7 +111,8 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
     last: Option[Vec[UInt]] = None,
     strb: Option[UInt] = None,
     stai: Option[UInt] = None,
-    endi: Option[UInt] = None
+    endi: Option[UInt] = None,
+    run: => Unit = {}
   ): Unit = {
     if (last.isDefined) {
       x.last.pokePartial(last.get)
@@ -128,6 +133,7 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
       x.endi.poke(endi.get)
     }
     x.valid.poke(true)
+    run
     fork
       .withRegion(Monitor) {
         x.ready.expect(true)
@@ -208,12 +214,14 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
     last: Option[Vec[UInt]] = None,
     strb: Option[UInt] = None,
     stai: Option[UInt] = None,
-    endi: Option[UInt] = None
+    endi: Option[UInt] = None,
+    run: => Unit = {}
   ): Unit = {
     x.ready.poke(true)
     fork
       .withRegion(Monitor) {
         x.valid.expect(true)
+        run
         x.el.expect(data)
         if (last.isDefined) {
           x.last.expect(last.get)
@@ -237,12 +245,14 @@ class TydiStreamDriver[Tel <: TydiEl, Tus <: Data](x: PhysicalStreamDetailed[Tel
     last: Option[Vec[UInt]] = None,
     strb: Option[UInt] = None,
     stai: Option[UInt] = None,
-    endi: Option[UInt] = None
+    endi: Option[UInt] = None,
+    run: => Unit = {}
   ): Unit = {
     x.ready.poke(true)
     fork
       .withRegion(Monitor) {
         x.valid.expect(true)
+        run
         if (strb.isDefined) {
           x.strb.expect(strb.get)
         } else {

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/TydiStreamDriverTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/TydiStreamDriverTest.scala
@@ -42,13 +42,15 @@ class TydiStreamDriverTest extends AnyFlatSpec with ChiselScalatestTester {
 
       c.out.expectInvalid()
       c.clock.step()
-      parallel({
-        c.in.enqueueElNow(testVal)
-        c.in.enqueueElNow(_.a -> 43.U, _.b -> false.B)
-      }, {
-        c.out.expectDequeueNow(_.a -> 42.U, _.b -> true.B)
-        c.out.expectDequeueNow(testVal2)
-      })
+      parallel(
+        {
+          c.in.enqueueElNow(testVal)
+          c.in.enqueueElNow(_.a -> 43.U, _.b -> false.B)
+        }, {
+          c.out.expectDequeueNow(_.a -> 42.U, _.b -> true.B)
+          c.out.expectDequeueNow(testVal2)
+        }
+      )
     }
   }
 }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/TydiStreamDriverTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/TydiStreamDriverTest.scala
@@ -42,13 +42,13 @@ class TydiStreamDriverTest extends AnyFlatSpec with ChiselScalatestTester {
 
       c.out.expectInvalid()
       c.clock.step()
-      parallel(c.in.enqueueElNow(testVal), c.out.expectDequeueNow(_.a -> 42.U, _.b -> true.B))
-      // Clock step is required because else we are still in the same moment as the parallel functions from before.
-      // Because they are timescoped, the printState does not give very interesting results.
-//      c.clock.step()
-//      state = c.out.printState()
-//      print(state)
-      parallel(c.in.enqueueElNow(_.a -> 43.U, _.b -> false.B), c.out.expectDequeueNow(testVal2))
+      parallel({
+        c.in.enqueueElNow(testVal)
+        c.in.enqueueElNow(_.a -> 43.U, _.b -> false.B)
+      }, {
+        c.out.expectDequeueNow(_.a -> 42.U, _.b -> true.B)
+        c.out.expectDequeueNow(testVal2)
+      })
     }
   }
 }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/TydiStreamDriverTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/TydiStreamDriverTest.scala
@@ -31,8 +31,8 @@ class TydiStreamDriverTest extends AnyFlatSpec with ChiselScalatestTester {
 
   it should "pass through an aggregate" in {
     test(new TydiPassthroughModule(new MyBundle)) { c =>
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       val whatever: Seq[MyBundle => (Data, Data)] = Seq(_.a -> 0.U, _.b -> false.B)
 

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/chisel/ChiselQueueTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/chisel/ChiselQueueTest.scala
@@ -56,8 +56,8 @@ class ChiselQueueTest extends AnyFlatSpec with ChiselScalatestTester {
     val myVec  = Vec(2, bundle)
 
     test(new QueueModule(myVec, 2)) { c =>
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       val testVal = myVec.Lit(0 -> bundle.Lit(_.a -> 42.U, _.b -> true.B), 1 -> bundle.Lit(_.a -> 43.U, _.b -> false.B))
       val testVal2 =
@@ -74,8 +74,8 @@ class ChiselQueueTest extends AnyFlatSpec with ChiselScalatestTester {
     val myVec = Vec(2, UInt(8.W))
 
     test(new QueueModule(myVec, 2)) { c =>
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       val testVal  = myVec.Lit(0 -> 42.U, 1 -> 43.U)
       val testVal2 = myVec.Lit(0 -> 44.U, 1 -> 45.U)
@@ -89,8 +89,8 @@ class ChiselQueueTest extends AnyFlatSpec with ChiselScalatestTester {
 
   it should "pass through an aggregate, using enqueueNow" in {
     test(new QueueModule(new MyBundle, 2)) { c =>
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       val bundle   = new MyBundle
       val testVal  = bundle.Lit(_.a -> 42.U, _.b -> true.B)
@@ -105,8 +105,8 @@ class ChiselQueueTest extends AnyFlatSpec with ChiselScalatestTester {
 
   it should "pass through elements, using enqueueNow" in {
     test(new QueueModule(UInt(8.W), 2)) { c =>
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       c.out.expectInvalid()
       c.in.enqueueNow(42.U)
@@ -117,8 +117,8 @@ class ChiselQueueTest extends AnyFlatSpec with ChiselScalatestTester {
 
   it should "pass through elements, using enqueueSeq" in {
     test(new QueueModule(UInt(8.W), 2)) { c =>
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       fork {
         c.in.enqueueSeq(Seq(42.U, 43.U, 44.U))
@@ -138,9 +138,7 @@ class ChiselQueueTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "work with a combinational queue" in {
     test(new PassthroughQueue(UInt(8.W))) { c =>
       c.in.initSource()
-      c.in.setSourceClock(c.clock)
       c.out.initSink()
-      c.out.setSinkClock(c.clock)
 
       fork {
         c.in.enqueueSeq(Seq(42.U, 43.U, 44.U))
@@ -158,16 +156,16 @@ class ChiselQueueTest extends AnyFlatSpec with ChiselScalatestTester {
       })
       io.out <> Queue(io.in)
     }) { c =>
-      c.io.in.initSource().setSourceClock(c.clock)
-      c.io.out.initSink().setSinkClock(c.clock)
+      c.io.in.initSource()
+      c.io.out.initSink()
       parallel(c.io.in.enqueueSeq(Seq(5.U, 2.U)), c.io.out.expectDequeueSeq(Seq(5.U, 2.U)))
     }
   }
 
   it should "enqueue/dequeue zero-width data" in {
     test(new QueueModule(UInt(0.W), 2)) { c =>
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       fork {
         c.in.enqueueSeq(Seq(0.U, 0.U, 0.U))

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExamplePlusTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExamplePlusTest.scala
@@ -42,7 +42,7 @@ class PipelineExamplePlusTest extends AnyFlatSpec with ChiselScalatestTester {
       val t1     = vecLitFromSeq(Seq(3, 6, 9, 28))
       val t1Last = Vec.Lit(0.U, 0.U, 0.U, 1.U)
 
-      c.in.enqueueNow(t1, endi = Some(2.U), last = Some(t1Last))
+      c.in.enqueueNow(t1, endi = Some(2.U), last = Some(t1Last), reset=true)
       println(c.out.printState(statsRenderer))
       c.clock.step()
       println(c.out.printState(statsRenderer))
@@ -57,10 +57,10 @@ class PipelineExamplePlusTest extends AnyFlatSpec with ChiselScalatestTester {
 
       c.clock.step()
       println(c.out.printState(statsRenderer))
-      c.in.enqueueNow(t2, endi = Some(3.U), last = Some(t2Last))
+      c.in.enqueueNow(t2, endi = Some(3.U), last = Some(t2Last), reset=true)
       println(c.out.printState(statsRenderer))
       c.out.expectInvalid()
-      c.in.enqueueNow(t3, endi = Some(3.U), last = Some(t3Last))
+      c.in.enqueueNow(t3, endi = Some(3.U), last = Some(t3Last), reset=true)
       println(c.out.printState(statsRenderer))
       c.clock.step()
       println(c.out.printState(statsRenderer))

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExamplePlusTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExamplePlusTest.scala
@@ -36,8 +36,8 @@ class PipelineExamplePlusTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "reduce" in {
     test(new ReducerWrap) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       val t1     = vecLitFromSeq(Seq(3, 6, 9, 28))
       val t1Last = Vec.Lit(0.U, 0.U, 0.U, 1.U)
@@ -71,8 +71,8 @@ class PipelineExamplePlusTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "process a sequence in the first half" in {
     test(new PipelineStartWrap) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       val t1     = vecLitFromSeq(Seq(-3, 6, 9, 28))
       val t1Last = Vec.Lit(0.U, 0.U, 0.U, 1.U)
@@ -96,8 +96,8 @@ class PipelineExamplePlusTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "process a sequence" in {
     test(new PipelineWrap) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       val t1     = vecLitFromSeq(Seq(-3, 6, 9, 28))
       val t1Last = Vec.Lit(0.U, 0.U, 0.U, 1.U)
@@ -139,8 +139,8 @@ class PipelineExamplePlusTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "process a sequence in parallel" in {
     test(new PipelineWrap) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       // define min and max values numbers are allowed to have
       val rangeMin = BigInt(Long.MinValue)

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExamplePlusTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExamplePlusTest.scala
@@ -42,7 +42,7 @@ class PipelineExamplePlusTest extends AnyFlatSpec with ChiselScalatestTester {
       val t1     = vecLitFromSeq(Seq(3, 6, 9, 28))
       val t1Last = Vec.Lit(0.U, 0.U, 0.U, 1.U)
 
-      c.in.enqueueNow(t1, endi = Some(2.U), last = Some(t1Last), reset=true)
+      c.in.enqueueNow(t1, endi = Some(2.U), last = Some(t1Last), reset = true)
       println(c.out.printState(statsRenderer))
       c.clock.step()
       println(c.out.printState(statsRenderer))
@@ -57,10 +57,10 @@ class PipelineExamplePlusTest extends AnyFlatSpec with ChiselScalatestTester {
 
       c.clock.step()
       println(c.out.printState(statsRenderer))
-      c.in.enqueueNow(t2, endi = Some(3.U), last = Some(t2Last), reset=true)
+      c.in.enqueueNow(t2, endi = Some(3.U), last = Some(t2Last), reset = true)
       println(c.out.printState(statsRenderer))
       c.out.expectInvalid()
-      c.in.enqueueNow(t3, endi = Some(3.U), last = Some(t3Last), reset=true)
+      c.in.enqueueNow(t3, endi = Some(3.U), last = Some(t3Last), reset = true)
       println(c.out.printState(statsRenderer))
       c.clock.step()
       println(c.out.printState(statsRenderer))

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExampleTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExampleTest.scala
@@ -16,8 +16,8 @@ class PipelineExampleTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "filter negative values" in {
     test(new NonNegativeFilterWrap) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       parallel(
         c.in.enqueueElNow(_.time -> 123976.U, _.value -> 6.S),
@@ -46,8 +46,8 @@ class PipelineExampleTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "reduce" in {
     test(new ReducerWrap) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       c.in.enqueueElNow(_.time -> 123976.U, _.value -> 6.S)
       println(c.out.printState())
@@ -66,8 +66,8 @@ class PipelineExampleTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "process a sequence" in {
     test(new PipelineWrap) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       // Enqueue first value
       c.in.enqueueElNow(_.time -> 123976.U, _.value -> 6.S)
@@ -99,8 +99,8 @@ class PipelineExampleTest extends AnyFlatSpec with ChiselScalatestTester {
   it should "process a sequence in parallel" in {
     test(new PipelineWrap) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
 
       // define min and max values numbers are allowed to have
       val rangeMin = BigInt(Long.MinValue)

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExampleTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/pipeline/PipelineExampleTest.scala
@@ -24,8 +24,7 @@ class PipelineExampleTest extends AnyFlatSpec with ChiselScalatestTester {
           c.in.enqueueElNow(_.time -> 123976.U, _.value -> 6.S)
           c.in.enqueueElNow(_.time -> 123976.U, _.value -> 0.S)
           c.in.enqueueElNow(_.time -> 123976.U, _.value -> -7.S)
-        },
-        {
+        }, {
           c.out.expectDequeueNow(c.out.elLit(_.time -> 123976.U, _.value -> 6.S))
           c.out.expectDequeueNow(c.out.elLit(_.time -> 123976.U, _.value -> 0.S))
           c.out.expectDequeueEmptyNow(strb = Some(0.U))

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/utils/ComplexityConverterTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/utils/ComplexityConverterTest.scala
@@ -205,8 +205,8 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
     // test case body here
     test(new ManualComplexityConverterFancyWrapper(new MyEl, stream, 10)) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
       println("N=1 test with fancy wrapper")
       println("Initializing signals")
 //      c.in.last.poke(c.in.last.Lit(0 -> 0.U))
@@ -306,8 +306,8 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
     // test case body here
     test(new ManualComplexityConverterFancyWrapper(char, stream, 20)) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
       c.in.endi.poke(stream.n - 1)
       c.in.strb.poke(0.U)
       println("She is a dolphin test")
@@ -457,8 +457,8 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
     // test case body here
     test(new ManualComplexityConverterFancyWrapper(char, stream, 20)) { c =>
       // Initialize signals
-      c.in.initSource().setSourceClock(c.clock)
-      c.out.initSink().setSinkClock(c.clock)
+      c.in.initSource()
+      c.out.initSink()
       c.in.endi.poke(stream.n - 1)
       c.in.strb.poke(0.U)
       println("Hello World test")

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/utils/ComplexityConverterTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/utils/ComplexityConverterTest.scala
@@ -327,7 +327,8 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
         {
           // Send some data in
           // shei
-          c.in.enqueueNow(t1,
+          c.in.enqueueNow(
+            t1,
             Option(Vec.Lit("b00".U(2.W), "b00".U, "b01".U, "b00".U)),
             Option(bRev("1111")),
             run = {
@@ -340,7 +341,8 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
           c.clock.step(1)
 
           // s_a_
-          c.in.enqueueNow(t3,
+          c.in.enqueueNow(
+            t3,
             Option(Vec.Lit("b01".U(2.W), "b00".U, "b01".U, "b00".U)),
             Option(bRev("1010")),
             run = {
@@ -351,7 +353,8 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
           println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // d_ol
-          c.in.enqueueNow(t4,
+          c.in.enqueueNow(
+            t4,
             Option(Vec.Lit("b00".U(2.W), "b00".U, "b00".U, "b00".U)),
             Option(bRev("1011")),
             run = {
@@ -362,7 +365,8 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
           println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // ph__
-          c.in.enqueueNow(t5,
+          c.in.enqueueNow(
+            t5,
             Option(Vec.Lit("b00".U(2.W), "b00".U, "b00".U, "b00".U)),
             Option(bRev("1100")),
             run = {
@@ -373,7 +377,8 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
           println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // __in
-          c.in.enqueueNow(t6,
+          c.in.enqueueNow(
+            t6,
             None,
             Option(bRev("0011")),
             run = {
@@ -505,9 +510,11 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
           println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // ce____
-          c.in.enqueueNow(t4,
+          c.in.enqueueNow(
+            t4,
             last = Some(Vec.Lit("b00".U(2.W), "b00".U, "b01".U, "b10".U, "b11".U, "b10".U)),
-            strb = Some(bRev("110000")))
+            strb = Some(bRev("110000"))
+          )
           print(c.in.printState(charRenderer))
 
           println("\n-- Transfer in 4")

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/utils/ComplexityConverterTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/utils/ComplexityConverterTest.scala
@@ -327,76 +327,71 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
         {
           // Send some data in
           // shei
-          timescope({
-            c.in.valid.poke(true)
-            c.in.data.pokePartial(t1)
-            c.in.strb.poke(bRev("1111"))
-            c.in.last.poke(Vec.Lit("b00".U(2.W), "b00".U, "b01".U, "b00".U))
-            println("\n-- Transfer in 1")
-            printInputState(c)
-            c.clock.step(1)
-            println(s"All data: ${c.exposed_storedData.peek().asString}")
-          })
+          c.in.enqueueNow(t1,
+            Option(Vec.Lit("b00".U(2.W), "b00".U, "b01".U, "b00".U)),
+            Option(bRev("1111")),
+            run = {
+              println("\n-- Transfer in 1")
+              printInputState(c)
+            }
+          )
+          println(s"All data: ${c.exposed_storedData.peek().asString}")
 
-          timescope({
-            c.clock.step(1)
-          })
+          c.clock.step(1)
 
           // s_a_
-          timescope({
-            c.in.valid.poke(true)
-            c.in.data.pokePartial(t3)
-            c.in.strb.poke(bRev("1010"))
-            c.in.last.poke(Vec.Lit("b01".U(2.W), "b00".U, "b01".U, "b00".U))
-            println("\n-- Transfer in 3")
-            printInputState(c)
-            c.clock.step(1)
-            println(s"All data: ${c.exposed_storedData.peek().asString}")
-          })
+          c.in.enqueueNow(t3,
+            Option(Vec.Lit("b01".U(2.W), "b00".U, "b01".U, "b00".U)),
+            Option(bRev("1010")),
+            run = {
+              println("\n-- Transfer in 3")
+              printInputState(c)
+            }
+          )
+          println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // d_ol
-          timescope({
-            c.in.valid.poke(true)
-            c.in.data.pokePartial(t4)
-            c.in.strb.poke(bRev("1011"))
-            c.in.last.poke(Vec.Lit("b00".U(2.W), "b00".U, "b00".U, "b00".U))
-            println("\n-- Transfer in 4")
-            printInputState(c)
-            c.clock.step(1)
-            println(s"All data: ${c.exposed_storedData.peek().asString}")
-          })
+          c.in.enqueueNow(t4,
+            Option(Vec.Lit("b00".U(2.W), "b00".U, "b00".U, "b00".U)),
+            Option(bRev("1011")),
+            run = {
+              println("\n-- Transfer in 4")
+              printInputState(c)
+            }
+          )
+          println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // ph__
-          timescope({
-            c.in.valid.poke(true)
-            c.in.data.pokePartial(t5)
-            c.in.strb.poke(bRev("1100"))
-            c.in.last.poke(Vec.Lit("b00".U(2.W), "b00".U, "b00".U, "b00".U))
-            println("\n-- Transfer in 5")
-            printInputState(c)
-            c.clock.step(1)
-            println(s"All data: ${c.exposed_storedData.peek().asString}")
-          })
+          c.in.enqueueNow(t5,
+            Option(Vec.Lit("b00".U(2.W), "b00".U, "b00".U, "b00".U)),
+            Option(bRev("1100")),
+            run = {
+              println("\n-- Transfer in 5")
+              printInputState(c)
+            }
+          )
+          println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // __in
-          timescope({
-            c.in.valid.poke(true)
-            c.in.data.pokePartial(t6)
-            c.in.strb.poke(bRev("0011"))
-            println("\n-- Transfer in 6")
-            printInputState(c)
-            c.clock.step(1)
-            println(s"All data: ${c.exposed_storedData.peek().asString}")
-          })
+          c.in.enqueueNow(t6,
+            None,
+            Option(bRev("0011")),
+            run = {
+              println("\n-- Transfer in 6")
+              printInputState(c)
+            }
+          )
+          println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // close off
-          timescope({
-            c.in.valid.poke(true)
-            c.in.last.poke(Vec.Lit("b11".U(2.W), "b00".U, "b00".U, "b00".U))
-            println("\n-- Transfer in 7")
-            printInputState(c)
-            c.clock.step(1)
-          })
+          c.in.enqueueEmptyNow(
+            Option(Vec.Lit("b11".U(2.W), "b00".U, "b00".U, "b00".U)),
+            Option(bRev("0000")),
+            run = {
+              println("\n-- Transfer in 7")
+              printInputState(c)
+            }
+          )
 
           println(s"All data: ${c.exposed_storedData.peek().asString}")
           println(s"All lasts: ${printVecBinary(c.exposed_storedLasts.peek())}")
@@ -510,21 +505,12 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
           println(s"All data: ${c.exposed_storedData.peek().asString}")
 
           // ce____
-//          c.in.enqueueNow(t4,
-//            last = Some(Vec.Lit("b00".U(2.W), "b00".U, "b01".U, "b10".U, "b11".U, "b10".U)),
-//            strb = Some(bRev("110000")))
+          c.in.enqueueNow(t4,
+            last = Some(Vec.Lit("b00".U(2.W), "b00".U, "b01".U, "b10".U, "b11".U, "b10".U)),
+            strb = Some(bRev("110000")))
+          print(c.in.printState(charRenderer))
 
-          timescope({
-            c.in.valid.poke(true)
-            c.in.data.pokePartial(t4)
-            c.in.last.poke(Vec.Lit("b00".U(2.W), "b00".U, "b01".U, "b10".U, "b11".U, "b10".U))
-            c.in.strb.poke(bRev("110000"))
-            print(c.in.printState(charRenderer))
-            c.clock.step(1)
-          })
           println("\n-- Transfer in 4")
-          println(s"All data: ${c.exposed_storedData.peek().asString}")
-
           println(s"All data: ${c.exposed_storedData.peek().asString}")
           println(s"All lasts: ${printVecBinary(c.exposed_storedLasts.peek())}")
         }, {


### PR DESCRIPTION
This PR updates the project to Chisel v6.3.0. Testing has been overhauled to comply with the updates in the v6 release of chiseltest, https://github.com/ucb-bar/chiseltest/pull/705.

The `timescope` functionality has been removed, in its place there is now a `reset` boolean for `enqueue` functions to reset all signals to `0`.
An optional `run` function argument can now be supplied for the `enqueue` and `dequeue` methods, e.g. for printing the interface state.
The common code has been extracted from the `enqueue` and `dequeue` methods respectively to remove unnecessary duplication.