### PR TITLE
Stream compatatibility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Concretely, this project contains:
     - Being able to work with the detailed bundles inside your components
     - Compliant with [Tydi-standard](https://abs-tudelft.github.io/tydi/specification/physical.html) for communication with components created outside of Chisel
     - Simple stream connection
+    - Stream compatibility checks
     - Helper functions for common signal use-cases
 - A stream-processing component chaining syntax
 - Testing utilities
@@ -252,7 +253,6 @@ Concretely, this project contains:
   - Create interoperability with [Fletcher](https://github.com/abs-tudelft/fletcher)
   - Investigate adoption of other hardware description languages
 - Library
-  - Stream compatibility checks
   - Better Union support
   - Interoperability with other streaming standards
   - Improved error handling and design rule checks

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -463,9 +463,7 @@ class PhysicalStream(private val e: TydiEl, n: Int = 1, d: Int = 1, c: Int, priv
    * @tparam Tel Element signal type.
    * @tparam Tus User signal type.
    */
-  def :=[Tel <: TydiEl, Tus <: Data](
-    bundle: PhysicalStreamDetailed[Tel, Tus]
-  ): Unit = {
+  def :=[Tel <: TydiEl, Tus <: Data](bundle: PhysicalStreamDetailed[Tel, Tus]): Unit = {
     this :~= bundle
     elementCheck(bundle)
     if (elWidth > 0) {

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -203,7 +203,6 @@ object CompatCheck extends Enumeration {
 }
 
 object CompatCheckResult extends Enumeration {
-  type Type = Value
   val Warning, Error = Value
 }
 
@@ -346,7 +345,7 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
 
   protected def reportProblem(
     problemStr: String
-  )(implicit typeCheckResult: CompatCheckResult.Type = CompatCheckResult.Error): Unit = {
+  )(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     typeCheckResult match {
       case CompatCheckResult.Error   => throw TydiStreamCompatException(problemStr)
       case CompatCheckResult.Warning => printWarning(problemStr)

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -426,13 +426,12 @@ sealed abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val 
     }
   }
 
-  def :=[TBel <: TydiEl, TBus <: Data](bundle: PhysicalStreamBase)(implicit typeCheck: CompatCheck.Value = CompatCheck.Strict): Unit = {
-    // TBel and TBus checking is not possible because of erasure.
+  def :=(bundle: PhysicalStreamBase)(implicit typeCheck: CompatCheck.Value = CompatCheck.Strict): Unit = {
     (this, bundle) match {
-      case (x: PhysicalStream, y: PhysicalStream) => x.connectSimple(y, typeCheck)
-      case (x: PhysicalStream, y: PhysicalStreamDetailed[TBel, TBus]) => x.connectDetailed(y, typeCheck)
-      case (x: PhysicalStreamDetailed[TBel, TBus], y: PhysicalStream) => x.connectSimple(y, typeCheck)
-      case (x: PhysicalStreamDetailed[TBel, TBus], y: PhysicalStreamDetailed[TBel, TBus]) => x.connectDetailed(y, typeCheck)
+      case (x: PhysicalStream, y: PhysicalStream)                             => x.connectSimple(y, typeCheck)
+      case (x: PhysicalStream, y: PhysicalStreamDetailed[_, _])               => x.connectDetailed(y, typeCheck)
+      case (x: PhysicalStreamDetailed[_, _], y: PhysicalStream)               => x.connectSimple(y, typeCheck)
+      case (x: PhysicalStreamDetailed[_, _], y: PhysicalStreamDetailed[_, _]) => x.connectDetailed(y, typeCheck)
     }
   }
 
@@ -491,7 +490,9 @@ class PhysicalStream(private val e: TydiEl, n: Int = 1, d: Int = 1, c: Int, priv
    * @tparam Tus User signal type.
    */
   private[tydi_chisel] def connectDetailed[Tel <: TydiEl, Tus <: Data](
-    bundle: PhysicalStreamDetailed[Tel, Tus], typeCheck: CompatCheck.Value = CompatCheck.Strict): Unit = {
+    bundle: PhysicalStreamDetailed[Tel, Tus],
+    typeCheck: CompatCheck.Value = CompatCheck.Strict
+  ): Unit = {
     this :~= bundle
     elementCheckTyped(bundle, typeCheck)
     if (elWidth > 0) {
@@ -510,7 +511,10 @@ class PhysicalStream(private val e: TydiEl, n: Int = 1, d: Int = 1, c: Int, priv
    * Stream mounting function.
    * @param bundle Source stream to drive this stream with.
    */
-  private[tydi_chisel] def connectSimple(bundle: PhysicalStream, typeCheck: CompatCheck.Value = CompatCheck.Strict): Unit = {
+  private[tydi_chisel] def connectSimple(
+    bundle: PhysicalStream,
+    typeCheck: CompatCheck.Value = CompatCheck.Strict
+  ): Unit = {
     this :~= bundle
     elementCheckTyped(bundle, typeCheck)
     this.data := bundle.data
@@ -640,7 +644,9 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
    * @param bundle Source stream to drive this stream with.
    */
   private[tydi_chisel] def connectDetailed[TBel <: TydiEl, TBus <: Data](
-    bundle: PhysicalStreamDetailed[TBel, TBus], typeCheck: CompatCheck.Value = CompatCheck.Strict): Unit = {
+    bundle: PhysicalStreamDetailed[TBel, TBus],
+    typeCheck: CompatCheck.Value = CompatCheck.Strict
+  ): Unit = {
     elementCheckTyped(bundle, typeCheck)
     // This could be done with a :<>= but I like being explicit here to catch possible errors.
     if (bundle.r && !this.r) {
@@ -686,7 +692,10 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
    * Stream mounting function.
    * @param bundle Source stream to drive this stream with.
    */
-  private[tydi_chisel] def connectSimple(bundle: PhysicalStream, typeCheck: CompatCheck.Value = CompatCheck.Strict): Unit = {
+  private[tydi_chisel] def connectSimple(
+    bundle: PhysicalStream,
+    typeCheck: CompatCheck.Value = CompatCheck.Strict
+  ): Unit = {
     paramCheck(bundle)
     elementCheckTyped(bundle, typeCheck)
     // We cannot use the :~= function here since the last vector must be driven by the bitvector

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -199,7 +199,6 @@ object BitsEl {
 }
 
 object CompatCheck extends Enumeration {
-  type CompatCheckType = Value
   val Params, Strict = Value
 }
 
@@ -612,7 +611,7 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
 
   def elementCheckTyped[TBel <: TydiEl, TBus <: Data](
     toConnect: PhysicalStreamDetailed[TBel, TBus],
-    typeCheck: CompatCheck.CompatCheckType
+    typeCheck: CompatCheck.Value
   ): Unit = {
     if (typeCheck == CompatCheck.Strict) {
       if (this.getDataType.getClass != toConnect.getDataType.getClass) {
@@ -637,7 +636,7 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
    */
   def :=[TBel <: TydiEl, TBus <: Data](
     bundle: PhysicalStreamDetailed[TBel, TBus]
-  )(implicit typeCheck: CompatCheck.CompatCheckType): Unit = {
+  )(implicit typeCheck: CompatCheck.Value): Unit = {
     elementCheckTyped(bundle, typeCheck)
     // This could be done with a :<>= but I like being explicit here to catch possible errors.
     if (bundle.r && !this.r) {

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -343,9 +343,7 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
     println(s"$bold$orange$message$reset")
   }
 
-  protected def reportProblem(
-    problemStr: String
-  )(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
+  protected def reportProblem(problemStr: String)(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     typeCheckResult match {
       case CompatCheckResult.Error   => throw TydiStreamCompatException(problemStr)
       case CompatCheckResult.Warning => printWarning(problemStr)
@@ -356,7 +354,7 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
    * Check if the parameters of a source and sink stream match.
    * @param toConnect Source stream to drive this stream with.
    */
-  def paramCheck(toConnect: PhysicalStreamBase): Unit = {
+  def paramCheck(toConnect: PhysicalStreamBase)(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     // Number of lanes should be the same
     if (toConnect.n != this.n) {
       reportProblem(s"Number of lanes between source and sink is not equal. ${this} has n=${this.n}, ${toConnect
@@ -374,7 +372,7 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
     }
   }
 
-  def elementCheck(toConnect: PhysicalStreamBase): Unit = {
+  def elementCheck(toConnect: PhysicalStreamBase)(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     if (this.elWidth != toConnect.elWidth) {
       reportProblem(
         s"Size of stream elements is not equal. ${this} has |e|=${this.elWidth}, ${toConnect} has |e|=${toConnect.elWidth}"
@@ -391,7 +389,7 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
    * Meta-connect function. Connects all metadata signals but not the data or user signals.
    * @param bundle Source stream to drive this stream with.
    */
-  def :~=(bundle: PhysicalStreamBase): Unit = {
+  def :~=(bundle: PhysicalStreamBase)(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     paramCheck(bundle)
     // This could be done with a :<>= but I like being explicit here to catch possible errors.
     this.endi    := bundle.endi
@@ -465,7 +463,9 @@ class PhysicalStream(private val e: TydiEl, n: Int = 1, d: Int = 1, c: Int, priv
    * @tparam Tel Element signal type.
    * @tparam Tus User signal type.
    */
-  def :=[Tel <: TydiEl, Tus <: Data](bundle: PhysicalStreamDetailed[Tel, Tus]): Unit = {
+  def :=[Tel <: TydiEl, Tus <: Data](
+    bundle: PhysicalStreamDetailed[Tel, Tus]
+  )(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     this :~= bundle
     elementCheck(bundle)
     if (elWidth > 0) {
@@ -484,7 +484,7 @@ class PhysicalStream(private val e: TydiEl, n: Int = 1, d: Int = 1, c: Int, priv
    * Stream mounting function.
    * @param bundle Source stream to drive this stream with.
    */
-  def :=(bundle: PhysicalStream): Unit = {
+  def :=(bundle: PhysicalStream)(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     this :~= bundle
     elementCheck(bundle)
     this.data := bundle.data
@@ -611,7 +611,7 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
   def elementCheckTyped[TBel <: TydiEl, TBus <: Data](
     toConnect: PhysicalStreamDetailed[TBel, TBus],
     typeCheck: CompatCheck.Value
-  ): Unit = {
+  )(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     if (typeCheck == CompatCheck.Strict) {
       if (this.getDataType.getClass != toConnect.getDataType.getClass) {
         reportProblem(
@@ -635,7 +635,7 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
    */
   def :=[TBel <: TydiEl, TBus <: Data](
     bundle: PhysicalStreamDetailed[TBel, TBus]
-  )(implicit typeCheck: CompatCheck.Value): Unit = {
+  )(implicit typeCheck: CompatCheck.Value, typeCheckResult: CompatCheckResult.Value): Unit = {
     elementCheckTyped(bundle, typeCheck)
     // This could be done with a :<>= but I like being explicit here to catch possible errors.
     if (bundle.r && !this.r) {
@@ -681,7 +681,7 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
    * Stream mounting function.
    * @param bundle Source stream to drive this stream with.
    */
-  def :=(bundle: PhysicalStream): Unit = {
+  def :=(bundle: PhysicalStream)(implicit typeCheckResult: CompatCheckResult.Value): Unit = {
     paramCheck(bundle)
     bundle.elementCheck(this)
     // We cannot use the :~= function here since the last vector must be driven by the bitvector

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -635,7 +635,7 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
    */
   def :=[TBel <: TydiEl, TBus <: Data](
     bundle: PhysicalStreamDetailed[TBel, TBus]
-  )(implicit typeCheck: CompatCheck.Value, typeCheckResult: CompatCheckResult.Value): Unit = {
+  )(implicit typeCheck: CompatCheck.Value = CompatCheck.Strict, typeCheckResult: CompatCheckResult.Value): Unit = {
     elementCheckTyped(bundle, typeCheck)
     // This could be done with a :<>= but I like being explicit here to catch possible errors.
     if (bundle.r && !this.r) {

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -338,29 +338,29 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
     // Number of lanes should be the same
     if (toConnect.n != this.n) {
       throw TydiStreamCompatException(
-        s"Number of lanes between source and sink is not equal. ${this.instanceName} has n=${this.n}, ${toConnect} has n=${toConnect.n}"
+        s"Number of lanes between source and sink is not equal. ${this} has n=${this.n}, ${toConnect.toString()} has n=${toConnect.n}"
       )
     }
     // Dimensionality should be the same
     if (toConnect.d != this.d) {
       throw TydiStreamCompatException(
-        s"Dimensionality of source and sink is not equal. ${this.instanceName} has d=${this.d}, ${toConnect} has d=${toConnect.d}"
+        s"Dimensionality of source and sink is not equal. ${this} has d=${this.d}, ${toConnect} has d=${toConnect.d}"
       )
     }
     // Sink C >= source C for compatibility
     if (toConnect.c > this.c) {
       throw TydiStreamCompatException(
-        s"Complexity of source stream > sink. ${this.instanceName} has c=${this.c}, ${toConnect} has c=${toConnect.c}"
+        s"Complexity of source stream > sink. ${this} has c=${this.c}, ${toConnect} has c=${toConnect.c}"
       )
     }
   }
 
   def elementCheck(toConnect: PhysicalStreamBase): Unit = {
     if (this.elWidth != toConnect.elWidth) {
-      throw TydiStreamCompatException("Size of stream elements is not equal")
+      throw TydiStreamCompatException(s"Size of stream elements is not equal. ${this} has |e|=${this.elWidth}, ${toConnect} has |e|=${toConnect.elWidth}")
     }
     if (this.userElWidth != toConnect.userElWidth) {
-      throw TydiStreamCompatException("Size of stream elements is not equal")
+      throw TydiStreamCompatException(s"Size of stream elements is not equal. ${this} has |u|=${this.userElWidth}, ${toConnect} has |u|=${toConnect.userElWidth}")
     }
   }
 
@@ -591,10 +591,10 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
   ): Unit = {
     if (typeCheck == CompatCheck.Strict) {
       if (this.getDataType.getClass != toConnect.getDataType.getClass) {
-        throw TydiStreamCompatException("Type of stream elements is not equal")
+        throw TydiStreamCompatException(s"Type of stream elements is not equal. ${this} has e=${this.getDataType.getClass}, ${toConnect} has e=${toConnect.getDataType.getClass}")
       }
       if (this.user.getClass != toConnect.user.getClass) {
-        throw TydiStreamCompatException("Type of user elements is not equal")
+        throw TydiStreamCompatException(s"Type of user elements is not equal. ${this} has u=${this.getUserType.getClass}, ${toConnect} has u=${toConnect.getUserType.getClass}")
       }
     } else {
       super.elementCheck(toConnect)

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -733,7 +733,6 @@ object PhysicalStreamDetailed {
 }
 
 trait TydiModuleMixin extends BaseModule with TranspileExtend {
-  implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict
   implicit var parentModule: TydiModuleMixin = this
 
   private val moduleList = ListBuffer[TydiModuleMixin]()

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -340,7 +340,7 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
     val reset  = "\u001b[0m"
 
     // Print the formatted message
-    println(s"$bold$orange$message$reset")
+    Console.err.println(s"$bold$orange$message$reset")
   }
 
   protected def reportProblem(problemStr: String): Unit = {

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -345,7 +345,9 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
     println(s"$bold$orange$message$reset")
   }
 
-  protected def reportProblem(problemStr: String, typeCheckResult: CompatCheckResult.Type): Unit = {
+  protected def reportProblem(
+    problemStr: String
+  )(implicit typeCheckResult: CompatCheckResult.Type = CompatCheckResult.Error): Unit = {
     typeCheckResult match {
       case CompatCheckResult.Error   => throw TydiStreamCompatException(problemStr)
       case CompatCheckResult.Warning => printWarning(problemStr)
@@ -356,48 +358,33 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
    * Check if the parameters of a source and sink stream match.
    * @param toConnect Source stream to drive this stream with.
    */
-  def paramCheck(
-    toConnect: PhysicalStreamBase,
-    typeCheckResult: CompatCheckResult.Type = CompatCheckResult.Error
-  ): Unit = {
+  def paramCheck(toConnect: PhysicalStreamBase): Unit = {
     // Number of lanes should be the same
     if (toConnect.n != this.n) {
-      reportProblem(
-        s"Number of lanes between source and sink is not equal. ${this} has n=${this.n}, ${toConnect
-            .toString()} has n=${toConnect.n}",
-        typeCheckResult
-      )
+      reportProblem(s"Number of lanes between source and sink is not equal. ${this} has n=${this.n}, ${toConnect
+          .toString()} has n=${toConnect.n}")
     }
     // Dimensionality should be the same
     if (toConnect.d != this.d) {
       reportProblem(
-        s"Dimensionality of source and sink is not equal. ${this} has d=${this.d}, ${toConnect} has d=${toConnect.d}",
-        typeCheckResult
+        s"Dimensionality of source and sink is not equal. ${this} has d=${this.d}, ${toConnect} has d=${toConnect.d}"
       )
     }
     // Sink C >= source C for compatibility
     if (toConnect.c > this.c) {
-      reportProblem(
-        s"Complexity of source stream > sink. ${this} has c=${this.c}, ${toConnect} has c=${toConnect.c}",
-        typeCheckResult
-      )
+      reportProblem(s"Complexity of source stream > sink. ${this} has c=${this.c}, ${toConnect} has c=${toConnect.c}")
     }
   }
 
-  def elementCheck(
-    toConnect: PhysicalStreamBase,
-    typeCheckResult: CompatCheckResult.Type = CompatCheckResult.Error
-  ): Unit = {
+  def elementCheck(toConnect: PhysicalStreamBase): Unit = {
     if (this.elWidth != toConnect.elWidth) {
       reportProblem(
-        s"Size of stream elements is not equal. ${this} has |e|=${this.elWidth}, ${toConnect} has |e|=${toConnect.elWidth}",
-        typeCheckResult
+        s"Size of stream elements is not equal. ${this} has |e|=${this.elWidth}, ${toConnect} has |e|=${toConnect.elWidth}"
       )
     }
     if (this.userElWidth != toConnect.userElWidth) {
       reportProblem(
-        s"Size of stream elements is not equal. ${this} has |u|=${this.userElWidth}, ${toConnect} has |u|=${toConnect.userElWidth}",
-        typeCheckResult
+        s"Size of stream elements is not equal. ${this} has |u|=${this.userElWidth}, ${toConnect} has |u|=${toConnect.userElWidth}"
       )
     }
   }
@@ -625,20 +612,17 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
 
   def elementCheckTyped[TBel <: TydiEl, TBus <: Data](
     toConnect: PhysicalStreamDetailed[TBel, TBus],
-    typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict,
-    typeCheckResult: CompatCheckResult.Type = CompatCheckResult.Error
+    typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict
   ): Unit = {
     if (typeCheck == CompatCheck.Strict) {
       if (this.getDataType.getClass != toConnect.getDataType.getClass) {
         reportProblem(
-          s"Type of stream elements is not equal. ${this} has e=${this.getDataType.getClass}, ${toConnect} has e=${toConnect.getDataType.getClass}",
-          typeCheckResult
+          s"Type of stream elements is not equal. ${this} has e=${this.getDataType.getClass}, ${toConnect} has e=${toConnect.getDataType.getClass}"
         )
       }
       if (this.user.getClass != toConnect.user.getClass) {
         reportProblem(
-          s"Type of user elements is not equal. ${this} has u=${this.getUserType.getClass}, ${toConnect} has u=${toConnect.getUserType.getClass}",
-          typeCheckResult
+          s"Type of user elements is not equal. ${this} has u=${this.getUserType.getClass}, ${toConnect} has u=${toConnect.getUserType.getClass}"
         )
       }
     } else {

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -612,7 +612,7 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
 
   def elementCheckTyped[TBel <: TydiEl, TBus <: Data](
     toConnect: PhysicalStreamDetailed[TBel, TBus],
-    typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict
+    typeCheck: CompatCheck.CompatCheckType
   ): Unit = {
     if (typeCheck == CompatCheck.Strict) {
       if (this.getDataType.getClass != toConnect.getDataType.getClass) {
@@ -637,7 +637,7 @@ class PhysicalStreamDetailed[Tel <: TydiEl, Tus <: Data](
    */
   def :=[TBel <: TydiEl, TBus <: Data](
     bundle: PhysicalStreamDetailed[TBel, TBus]
-  )(implicit typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict): Unit = {
+  )(implicit typeCheck: CompatCheck.CompatCheckType): Unit = {
     elementCheckTyped(bundle, typeCheck)
     // This could be done with a :<>= but I like being explicit here to catch possible errors.
     if (bundle.r && !this.r) {
@@ -733,6 +733,7 @@ object PhysicalStreamDetailed {
 }
 
 trait TydiModuleMixin extends BaseModule with TranspileExtend {
+  implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict
   implicit var parentModule: TydiModuleMixin = this
 
   private val moduleList = ListBuffer[TydiModuleMixin]()

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -343,8 +343,8 @@ abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val d: Int,
     println(s"$bold$orange$message$reset")
   }
 
-  protected def reportProblem(problemStr: String)(implicit typeCheckResult: CompatCheckResult.Value = CompatCheckResult.Error): Unit = {
-    typeCheckResult match {
+  protected def reportProblem(problemStr: String): Unit = {
+    compatCheckResult match {
       case CompatCheckResult.Error   => throw TydiStreamCompatException(problemStr)
       case CompatCheckResult.Warning => printWarning(problemStr)
     }

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/examples/timestamped_message/TimestampedMessage.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/examples/timestamped_message/TimestampedMessage.scala
@@ -24,7 +24,7 @@ class TimestampedMessageBundle extends Group {
     val a: UInt = UInt(8.W)
     val b: Bool = Bool()
   }*/
-  val message = new PhysicalStreamDetailed(BitsEl(charWidth), n = 3, d = 1, c = 7)
+  val message = new PhysicalStreamDetailed(BitsEl(charWidth), n = 3, d = 2, c = 7)
 }
 
 // Declaration of the module
@@ -67,7 +67,7 @@ class TimestampedMessageModuleOut extends TydiModule {
 }
 
 class TimestampedMessageModuleIn extends TydiModule {
-  val io1 = IO(Flipped(new PhysicalStream(new TimestampedMessageBundle, n = 1, d = 2, c = 7, u = new Null())))
+  val io1 = IO(Flipped(new PhysicalStream(new TimestampedMessageBundle, n = 1, d = 1, c = 7, u = new Null())))
   val io2 = IO(Flipped(new PhysicalStream(BitsEl(8.W), n = 3, d = 2, c = 7, u = new Null())))
   io1 :<= DontCare
   io1.ready := DontCare

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
@@ -6,5 +6,5 @@ package object tydi_chisel {
   val firReleaseOpts: Array[String]        = Array("-O=release", "-disable-all-randomization", "-strip-debug-info")
 
 //  implicit val typeCheck: CompatCheck.Value = CompatCheck.Strict
-  implicit val typeCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
+//  implicit val typeCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
 }

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
@@ -4,4 +4,6 @@ package object tydi_chisel {
   val firNoOptimizationOpts: Array[String] = Array("-disable-opt", "-disable-all-randomization", "-strip-debug-info")
   val firNormalOpts: Array[String]         = Array("-O=debug", "-disable-all-randomization", "-strip-debug-info")
   val firReleaseOpts: Array[String]        = Array("-O=release", "-disable-all-randomization", "-strip-debug-info")
+
+  implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict
 }

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
@@ -4,12 +4,4 @@ package object tydi_chisel {
   val firNoOptimizationOpts: Array[String] = Array("-disable-opt", "-disable-all-randomization", "-strip-debug-info")
   val firNormalOpts: Array[String]         = Array("-O=debug", "-disable-all-randomization", "-strip-debug-info")
   val firReleaseOpts: Array[String]        = Array("-O=release", "-disable-all-randomization", "-strip-debug-info")
-
-  private[this] var _compatCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
-
-  def compatCheckResult: CompatCheckResult.Value = _compatCheckResult
-
-  def setCompatCheckResult(value: CompatCheckResult.Value): Unit = {
-    _compatCheckResult = value
-  }
 }

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
@@ -5,6 +5,11 @@ package object tydi_chisel {
   val firNormalOpts: Array[String]         = Array("-O=debug", "-disable-all-randomization", "-strip-debug-info")
   val firReleaseOpts: Array[String]        = Array("-O=release", "-disable-all-randomization", "-strip-debug-info")
 
-//  implicit val typeCheck: CompatCheck.Value = CompatCheck.Strict
-//  implicit val typeCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
+  private[this] var _compatCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
+
+  def compatCheckResult: CompatCheckResult.Value = _compatCheckResult
+
+  def setCompatCheckResult(value: CompatCheckResult.Value): Unit = {
+    _compatCheckResult = value
+  }
 }

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
@@ -6,4 +6,5 @@ package object tydi_chisel {
   val firReleaseOpts: Array[String]        = Array("-O=release", "-disable-all-randomization", "-strip-debug-info")
 
   implicit val typeCheck: CompatCheck.Value = CompatCheck.Strict
+  implicit val typeCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
 }

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
@@ -5,6 +5,6 @@ package object tydi_chisel {
   val firNormalOpts: Array[String]         = Array("-O=debug", "-disable-all-randomization", "-strip-debug-info")
   val firReleaseOpts: Array[String]        = Array("-O=release", "-disable-all-randomization", "-strip-debug-info")
 
-  implicit val typeCheck: CompatCheck.Value = CompatCheck.Strict
+//  implicit val typeCheck: CompatCheck.Value = CompatCheck.Strict
   implicit val typeCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
 }

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
@@ -5,5 +5,5 @@ package object tydi_chisel {
   val firNormalOpts: Array[String]         = Array("-O=debug", "-disable-all-randomization", "-strip-debug-info")
   val firReleaseOpts: Array[String]        = Array("-O=release", "-disable-all-randomization", "-strip-debug-info")
 
-  implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict
+  implicit val typeCheck: CompatCheck.Value = CompatCheck.Strict
 }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -29,14 +29,14 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
   class DetailedStreamConnectMod[TIel <: TydiEl, TIus <: Data, TOel <: TydiEl, TOus <: Data](
     in: PhysicalStreamDetailed[TIel, TIus],
     out: PhysicalStreamDetailed[TOel, TOus],
-    typeCheck: CompatCheck.Value = CompatCheck.Strict
+    typeCheckSelect: CompatCheck.Value = CompatCheck.Strict
   ) extends TydiModule {
     val inStream: PhysicalStreamDetailed[TIel, TIus]  = IO(Flipped(in)).flip
     val outStream: PhysicalStreamDetailed[TOel, TOus] = IO(out)
 
     {
       // Value gets correctly overridden
-      implicit val typeCheckImplicit: CompatCheck.Value = typeCheck
+      implicit val typeCheckImplicit: CompatCheck.Value = typeCheckSelect
       outStream := inStream
     }
   }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -24,6 +24,7 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     in: PhysicalStreamDetailed[TIel, TIus],
     out: PhysicalStreamDetailed[TOel, TOus]
   ) extends TydiModule {
+    override implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
     val inStream: PhysicalStreamDetailed[TIel, TIus]  = IO(Flipped(in)).flip
     val outStream: PhysicalStreamDetailed[TOel, TOus] = IO(out)
     outStream := inStream
@@ -44,6 +45,12 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     intercept[TydiStreamCompatException] {
       test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream)) { _ => }
     }
+  }
+
+  it should "weak check type" in {
+    implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
+    implicit val integer: Int = 5
+    test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream)) { _ => }
   }
 
   it should "check parameters" in {

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -24,7 +24,8 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     in: PhysicalStreamDetailed[TIel, TIus],
     out: PhysicalStreamDetailed[TOel, TOus]
   ) extends TydiModule {
-    override implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
+    // The following works for overriding the implicit variable from the package object:
+    // implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
     val inStream: PhysicalStreamDetailed[TIel, TIus]  = IO(Flipped(in)).flip
     val outStream: PhysicalStreamDetailed[TOel, TOus] = IO(out)
     outStream := inStream
@@ -48,6 +49,7 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
   }
 
   it should "weak check type" in {
+    // The following does not work for overriding the implicit variable from the package object:
     implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
     implicit val integer: Int = 5
     test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream)) { _ => }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -1,0 +1,43 @@
+package nl.tudelft.tydi_chisel
+
+import chisel3._
+import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
+import chiseltest._
+import nl.tudelft.tydi_chisel_test.Conversions._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
+  class MyBundle extends Group {
+    val a: UInt = UInt(8.W)
+    val b: Bool = Bool()
+  }
+
+  class MyBundle2 extends MyBundle
+
+  class StreamConnectMod(in: PhysicalStream, out: PhysicalStream) extends TydiModule {
+    private val inStream = Wire(in)
+    private val outStream = Wire(out)
+    outStream := inStream
+    out := in
+  }
+
+  class DetailedStreamConnectMod[TIel <: TydiEl, TIus <: Data, TOel <: TydiEl, TOus <: Data](
+    in: PhysicalStreamDetailed[TIel, TIus],
+    out: PhysicalStreamDetailed[TOel, TOus]
+  ) extends TydiModule {
+    private val inStream = Wire(in)
+    private val outStream = Wire(out)
+    outStream := inStream
+  }
+
+  private val myBundleStream = new PhysicalStreamDetailed(new MyBundle, c=8)
+  private val myBundle2Stream = new PhysicalStreamDetailed(new MyBundle2, c=8)
+
+  behavior of "Stream compatibility check"
+
+  it should "check type" in {
+    intercept[TydiStreamCompatException] {
+      test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream)) { _ => }
+    }
+  }
+}

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -17,9 +17,10 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
   class StreamConnectMod(
     in: PhysicalStream,
     out: PhysicalStream,
-    errorReporting: CompatCheckResult.Value = CompatCheckResult.Error
+    // This only works if it shadows the name of the package implicit definition
+    typeCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
   ) extends TydiModule {
-    implicit val errorReportingImplicit: CompatCheckResult.Value = errorReporting
+    implicit val errorReportingImplicit: CompatCheckResult.Value = typeCheckResult
     val inStream: PhysicalStream  = IO(Flipped(in))
     val outStream: PhysicalStream = IO(out)
     outStream := inStream

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -64,7 +64,7 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
 
   it should "weak check type" in {
     test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream, CompatCheck.Params)) { _ => }
-    test(new StreamConnectMod(PhysicalStream(new MyBundle, c = 1), PhysicalStream(new MyBundle2, c = 1))) { _ => }
+    test(new StreamConnectMod(PhysicalStream(new MyBundle, c = 1), PhysicalStream(new MyBundle2, c = 1), CompatCheck.Params)) { _ => }
   }
 
   it should "check parameters" in {

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -15,12 +15,17 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
   class StreamConnectMod(
     in: PhysicalStream,
     out: PhysicalStream,
+    typeCheckSelect: CompatCheck.Value = CompatCheck.Strict,
     errorReporting: CompatCheckResult.Value = CompatCheckResult.Error
   ) extends TydiModule {
     nl.tudelft.tydi_chisel setCompatCheckResult errorReporting
     val inStream: PhysicalStream  = IO(Flipped(in))
     val outStream: PhysicalStream = IO(out)
-    outStream := inStream
+
+    {
+      implicit val typeCheckImplicit: CompatCheck.Value = typeCheckSelect
+      outStream := inStream
+    }
   }
 
   class DetailedStreamConnectMod[TIel <: TydiEl, TIus <: Data, TOel <: TydiEl, TOus <: Data](
@@ -32,7 +37,6 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     val outStream: PhysicalStreamDetailed[TOel, TOus] = IO(out)
 
     {
-      // Value gets correctly overridden
       implicit val typeCheckImplicit: CompatCheck.Value = typeCheckSelect
       outStream := inStream
     }
@@ -53,10 +57,14 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     intercept[TydiStreamCompatException] {
       test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream)) { _ => }
     }
+    intercept[TydiStreamCompatException] {
+      test(new StreamConnectMod(PhysicalStream(new MyBundle, c = 1), PhysicalStream(new MyBundle2, c = 1))) { _ => }
+    }
   }
 
   it should "weak check type" in {
     test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream, CompatCheck.Params)) { _ => }
+    test(new StreamConnectMod(PhysicalStream(new MyBundle, c = 1), PhysicalStream(new MyBundle2, c = 1))) { _ => }
   }
 
   it should "check parameters" in {
@@ -92,7 +100,7 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
         new StreamConnectMod(
           baseStream,
           PhysicalStream(new MyBundle, n = 2, d = 1, c = 1, new DataBundle),
-          CompatCheckResult.Warning
+          errorReporting=CompatCheckResult.Warning
         )
       ) { _ => }
     }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -95,7 +95,13 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     // Same parameters
     val stream = new java.io.ByteArrayOutputStream()
     Console.withErr(stream) {
-      test(new StreamConnectMod(baseStream, PhysicalStream(new MyBundle, n = 2, d = 1, c = 1, new DataBundle), CompatCheckResult.Warning)) { _ => }
+      test(
+        new StreamConnectMod(
+          baseStream,
+          PhysicalStream(new MyBundle, n = 2, d = 1, c = 1, new DataBundle),
+          CompatCheckResult.Warning
+        )
+      ) { _ => }
     }
     // Check if error was written to console
     assert(stream.toString contains "Number of lanes between source and sink is not equal.")

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -22,13 +22,22 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
 
   class DetailedStreamConnectMod[TIel <: TydiEl, TIus <: Data, TOel <: TydiEl, TOus <: Data](
     in: PhysicalStreamDetailed[TIel, TIus],
-    out: PhysicalStreamDetailed[TOel, TOus]
+    out: PhysicalStreamDetailed[TOel, TOus],
+    typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict
   ) extends TydiModule {
     // The following works for overriding the implicit variable from the package object:
     // implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
     val inStream: PhysicalStreamDetailed[TIel, TIus]  = IO(Flipped(in)).flip
     val outStream: PhysicalStreamDetailed[TOel, TOus] = IO(out)
-    outStream := inStream
+
+    // Just to check override
+    implicit val typeCheckImplicit: CompatCheck.CompatCheckType = CompatCheck.Strict
+
+    {
+      // Value gets correctly overridden
+      implicit val typeCheckImplicit: CompatCheck.CompatCheckType = typeCheck
+      outStream := inStream
+    }
   }
 
   class DataBundle extends Bundle {
@@ -50,9 +59,9 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
 
   it should "weak check type" in {
     // The following does not work for overriding the implicit variable from the package object:
-    implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
-    implicit val integer: Int = 5
-    test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream)) { _ => }
+//    implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
+//    implicit val integer: Int = 5
+    test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream, CompatCheck.Params)) { _ => }
   }
 
   it should "check parameters" in {

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -93,6 +93,11 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     }
 
     // Same parameters
-    test(new StreamConnectMod(baseStream, PhysicalStream(new MyBundle, n = 2, d = 1, c = 1, new DataBundle), CompatCheckResult.Warning)) { _ => }
+    val stream = new java.io.ByteArrayOutputStream()
+    Console.withErr(stream) {
+      test(new StreamConnectMod(baseStream, PhysicalStream(new MyBundle, n = 2, d = 1, c = 1, new DataBundle), CompatCheckResult.Warning)) { _ => }
+    }
+    // Check if error was written to console
+    assert(stream.toString contains "Number of lanes between source and sink is not equal.")
   }
 }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -18,12 +18,12 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     typeCheckSelect: CompatCheck.Value = CompatCheck.Strict,
     errorReporting: CompatCheckResult.Value = CompatCheckResult.Error
   ) extends TydiModule {
-    nl.tudelft.tydi_chisel setCompatCheckResult errorReporting
     val inStream: PhysicalStream  = IO(Flipped(in))
     val outStream: PhysicalStream = IO(out)
 
     {
       implicit val typeCheckImplicit: CompatCheck.Value = typeCheckSelect
+      implicit val typeCheckResultImplicit: CompatCheckResult.Value = errorReporting
       outStream := inStream
     }
   }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -20,7 +20,7 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     // This only works if it shadows the name of the package implicit definition
     errorReporting: CompatCheckResult.Value = CompatCheckResult.Error
   ) extends TydiModule {
-    implicit val errorReportingImplicit: CompatCheckResult.Value = errorReporting
+    nl.tudelft.tydi_chisel setCompatCheckResult errorReporting
     val inStream: PhysicalStream  = IO(Flipped(in))
     val outStream: PhysicalStream = IO(out)
     outStream := inStream

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -18,9 +18,9 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     in: PhysicalStream,
     out: PhysicalStream,
     // This only works if it shadows the name of the package implicit definition
-    typeCheckResult: CompatCheckResult.Value = CompatCheckResult.Error
+    errorReporting: CompatCheckResult.Value = CompatCheckResult.Error
   ) extends TydiModule {
-    implicit val errorReportingImplicit: CompatCheckResult.Value = typeCheckResult
+    implicit val errorReportingImplicit: CompatCheckResult.Value = errorReporting
     val inStream: PhysicalStream  = IO(Flipped(in))
     val outStream: PhysicalStream = IO(out)
     outStream := inStream

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -22,7 +22,7 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
     val outStream: PhysicalStream = IO(out)
 
     {
-      implicit val typeCheckImplicit: CompatCheck.Value = typeCheckSelect
+      implicit val typeCheckImplicit: CompatCheck.Value             = typeCheckSelect
       implicit val typeCheckResultImplicit: CompatCheckResult.Value = errorReporting
       outStream := inStream
     }
@@ -64,7 +64,13 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
 
   it should "weak check type" in {
     test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream, CompatCheck.Params)) { _ => }
-    test(new StreamConnectMod(PhysicalStream(new MyBundle, c = 1), PhysicalStream(new MyBundle2, c = 1), CompatCheck.Params)) { _ => }
+    test(
+      new StreamConnectMod(
+        PhysicalStream(new MyBundle, c = 1),
+        PhysicalStream(new MyBundle2, c = 1),
+        CompatCheck.Params
+      )
+    ) { _ => }
   }
 
   it should "check parameters" in {
@@ -100,7 +106,7 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
         new StreamConnectMod(
           baseStream,
           PhysicalStream(new MyBundle, n = 2, d = 1, c = 1, new DataBundle),
-          errorReporting=CompatCheckResult.Warning
+          errorReporting = CompatCheckResult.Warning
         )
       ) { _ => }
     }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -1,9 +1,7 @@
 package nl.tudelft.tydi_chisel
 
 import chisel3._
-import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 import chiseltest._
-import nl.tudelft.tydi_chisel_test.Conversions._
 import org.scalatest.flatspec.AnyFlatSpec
 
 class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
@@ -17,7 +15,6 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
   class StreamConnectMod(
     in: PhysicalStream,
     out: PhysicalStream,
-    // This only works if it shadows the name of the package implicit definition
     errorReporting: CompatCheckResult.Value = CompatCheckResult.Error
   ) extends TydiModule {
     nl.tudelft.tydi_chisel setCompatCheckResult errorReporting
@@ -87,12 +84,8 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
 
   it should "print warnings" in {
     val baseStream = PhysicalStream(new MyBundle, n = 1, d = 1, c = 1, new DataBundle)
-    class StreamConnectWarningsMod(in: PhysicalStream, out: PhysicalStream)
-          extends StreamConnectMod(in: PhysicalStream, out: PhysicalStream) {
-      implicit val errorReporting: CompatCheckResult.Value = CompatCheckResult.Warning
-    }
 
-    // Same parameters
+    // Create a module with warning output and give it incompatible streams.
     val stream = new java.io.ByteArrayOutputStream()
     Console.withErr(stream) {
       test(

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -15,27 +15,27 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
   class MyBundle2 extends MyBundle
 
   class StreamConnectMod(in: PhysicalStream, out: PhysicalStream) extends TydiModule {
-    private val inStream = Wire(in)
-    private val outStream = Wire(out)
+    val inStream: PhysicalStream  = IO(Flipped(in))
+    val outStream: PhysicalStream = IO(out)
     outStream := inStream
-    out := in
   }
 
   class DetailedStreamConnectMod[TIel <: TydiEl, TIus <: Data, TOel <: TydiEl, TOus <: Data](
     in: PhysicalStreamDetailed[TIel, TIus],
     out: PhysicalStreamDetailed[TOel, TOus]
   ) extends TydiModule {
-    private val inStream = Wire(in)
-    private val outStream = Wire(out)
+    val inStream: PhysicalStreamDetailed[TIel, TIus]  = IO(Flipped(in)).flip
+    val outStream: PhysicalStreamDetailed[TOel, TOus] = IO(out)
     outStream := inStream
   }
 
-  private val myBundleStream = new PhysicalStreamDetailed(new MyBundle, c=8)
-  private val myBundle2Stream = new PhysicalStreamDetailed(new MyBundle2, c=8)
+  private val myBundleStream  = new PhysicalStreamDetailed(new MyBundle, c = 8)
+  private val myBundle2Stream = new PhysicalStreamDetailed(new MyBundle2, c = 8)
 
   behavior of "Stream compatibility check"
 
   it should "check type" in {
+    test(new DetailedStreamConnectMod(myBundleStream, myBundleStream)) { _ => }
     intercept[TydiStreamCompatException] {
       test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream)) { _ => }
     }

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/StreamCompatCheckTest.scala
@@ -23,19 +23,14 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
   class DetailedStreamConnectMod[TIel <: TydiEl, TIus <: Data, TOel <: TydiEl, TOus <: Data](
     in: PhysicalStreamDetailed[TIel, TIus],
     out: PhysicalStreamDetailed[TOel, TOus],
-    typeCheck: CompatCheck.CompatCheckType = CompatCheck.Strict
+    typeCheck: CompatCheck.Value = CompatCheck.Strict
   ) extends TydiModule {
-    // The following works for overriding the implicit variable from the package object:
-    // implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
     val inStream: PhysicalStreamDetailed[TIel, TIus]  = IO(Flipped(in)).flip
     val outStream: PhysicalStreamDetailed[TOel, TOus] = IO(out)
 
-    // Just to check override
-    implicit val typeCheckImplicit: CompatCheck.CompatCheckType = CompatCheck.Strict
-
     {
       // Value gets correctly overridden
-      implicit val typeCheckImplicit: CompatCheck.CompatCheckType = typeCheck
+      implicit val typeCheckImplicit: CompatCheck.Value = typeCheck
       outStream := inStream
     }
   }
@@ -58,9 +53,6 @@ class StreamCompatCheckTest extends AnyFlatSpec with ChiselScalatestTester {
   }
 
   it should "weak check type" in {
-    // The following does not work for overriding the implicit variable from the package object:
-//    implicit val typeCheck: CompatCheck.CompatCheckType = CompatCheck.Params
-//    implicit val integer: Int = 5
     test(new DetailedStreamConnectMod(myBundleStream, myBundle2Stream, CompatCheck.Params)) { _ => }
   }
 

--- a/testing/src/test/scala/nl/tudelft/tydi_chisel/utils/ComplexityConverterTest.scala
+++ b/testing/src/test/scala/nl/tudelft/tydi_chisel/utils/ComplexityConverterTest.scala
@@ -200,7 +200,7 @@ class ComplexityConverterTest extends AnyFlatSpec with ChiselScalatestTester {
   }
 
   it should "work with fancy wrapper" in {
-    val stream = PhysicalStream(new MyEl, n = 1, d = 1, c = 7)
+    val stream = PhysicalStream(new MyEl, n = 1, d = 1, c = 8)
 
     // test case body here
     test(new ManualComplexityConverterFancyWrapper(new MyEl, stream, 10)) { c =>


### PR DESCRIPTION
This PR adds support for compatibility checking of streams.

There are three types of checks:

1. Parameter checks (`n`, `d`, `c`)
2. Basic data & user type checks (number of bits equal?)
3. Advanced data & user type checks (do the classes match?)

One can select the strictness of the check through an implicit parameter of type `CompatCheck`. The strict check is default and checks if both streams use the same data-type. The weaker check (called `Parameter`) only checks the bit width of the used data-types.
One can select if errors should be thrown on incompatible streams or to print warnings (useful if checking all the issues in a design since execution stops at exceptions) by an implicit parameter of type `CompatCheckResult`.

The connection function `:=` is now defined in the `PhysicalStreamBase` class and calls the correct data connection methods through matching and upcasting the arguments. This has the advantage that `:=` can now use default arguments as there are no overloaded methods anymore.

`:@=` is the meta-connect function that only connects the meta signals of two streams and checks the parameter compatibility.
`:~=` is a shorthand for using `:=` in an environment where `implicit val errorReporting: CompatCheck.Value = CompatCheck.Params`. I.e.: quick weak connect function.

Two examples/tests were updated because they had incompatible streams.