### PR TITLE
Better reporting

### DIFF
--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -352,7 +352,7 @@ sealed abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val 
     checkResult match {
       case CompatCheckResult.Error => throw TydiStreamCompatException(problemStr)
       case CompatCheckResult.Warning => {
-        val stackTrace = new Exception().getStackTrace.slice(2, 8).mkString(". Trace:\n\t", "\n\t", "\n")
+        val stackTrace = new Exception().getStackTrace.slice(2, 8).mkString("\nTrace:\n\t", "\n\t", "\n")
         printWarning(problemStr + stackTrace)
       }
     }
@@ -366,22 +366,21 @@ sealed abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val 
     // Number of lanes should be the same
     if (toConnect.n != this.n) {
       reportProblem(
-        s"Number of lanes between source and sink is not equal. ${this} has n=${this.n}, ${toConnect
-            .toString()} has n=${toConnect.n}",
+        s"Number of lanes between source and sink is not equal.\n\t- ${this} has n=${this.n}\n\t- ${toConnect} has n=${toConnect.n}",
         compatCheckResult
       )
     }
     // Dimensionality should be the same
     if (toConnect.d != this.d) {
       reportProblem(
-        s"Dimensionality of source and sink is not equal. ${this} has d=${this.d}, ${toConnect} has d=${toConnect.d}",
+        s"Dimensionality of source and sink is not equal.\n\t- ${this} has d=${this.d}\n\t- ${toConnect} has d=${toConnect.d}",
         compatCheckResult
       )
     }
     // Sink C >= source C for compatibility
     if (toConnect.c > this.c) {
       reportProblem(
-        s"Complexity of source stream > sink. ${this} has c=${this.c}, ${toConnect} has c=${toConnect.c}",
+        s"Complexity of source stream > sink.\n\t- ${this} has c=${this.c}\n\t- ${toConnect} has c=${toConnect.c}",
         compatCheckResult
       )
     }
@@ -390,13 +389,13 @@ sealed abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val 
   def elementCheck(toConnect: PhysicalStreamBase, compatCheckResult: CompatCheckResult.Value): Unit = {
     if (this.elWidth != toConnect.elWidth) {
       reportProblem(
-        s"Size of stream elements is not equal. ${this} has |e|=${this.elWidth}, ${toConnect} has |e|=${toConnect.elWidth}",
+        s"Size of stream elements is not equal.\n\t- ${this} has |e|=${this.elWidth}\n\t- ${toConnect} has |e|=${toConnect.elWidth}",
         compatCheckResult
       )
     }
     if (this.userElWidth != toConnect.userElWidth) {
       reportProblem(
-        s"Size of stream elements is not equal. ${this} has |u|=${this.userElWidth}, ${toConnect} has |u|=${toConnect.userElWidth}",
+        s"Size of stream elements is not equal.\n\t- ${this} has |u|=${this.userElWidth}\n\t- ${toConnect} has |u|=${toConnect.userElWidth}",
         compatCheckResult
       )
     }
@@ -415,13 +414,13 @@ sealed abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val 
     if (check == CompatCheck.Strict) {
       if (this.getDataType.getClass != toConnect.getDataType.getClass) {
         reportProblem(
-          s"Type of stream elements is not equal. ${this} has e=${this.getDataType.getClass}, ${toConnect} has e=${toConnect.getDataType.getClass}",
+          s"Type of stream elements is not equal.\n\t- ${this} has e=${this.getDataType.getClass}, |e|=${this.elWidth}\n\t- ${toConnect} has e=${toConnect.getDataType.getClass}, |e|=${toConnect.elWidth}",
           compatCheckResult
         )
       }
       if (this.getUserType.getClass != toConnect.getUserType.getClass) {
         reportProblem(
-          s"Type of user elements is not equal. ${this} has u=${this.getUserType.getClass}, ${toConnect} has u=${toConnect.getUserType.getClass}",
+          s"Type of user elements is not equal.\n\t- ${this} has u=${this.getUserType.getClass}, |u|=${this.userElWidth}\n\t- ${toConnect} has u=${toConnect.getUserType.getClass}, |u|=${toConnect.userElWidth}",
           compatCheckResult
         )
       }

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -350,8 +350,11 @@ sealed abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val 
     }
 
     checkResult match {
-      case CompatCheckResult.Error   => throw TydiStreamCompatException(problemStr)
-      case CompatCheckResult.Warning => printWarning(problemStr)
+      case CompatCheckResult.Error => throw TydiStreamCompatException(problemStr)
+      case CompatCheckResult.Warning => {
+        val stackTrace = new Exception().getStackTrace.slice(2, 8).mkString(". Trace:\n\t", "\n\t", "\n")
+        printWarning(problemStr + stackTrace)
+      }
     }
   }
 

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiLib.scala
@@ -344,7 +344,12 @@ sealed abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val 
   }
 
   protected def reportProblem(problemStr: String, compatCheckResult: CompatCheckResult.Value): Unit = {
-    compatCheckResult match {
+    val checkResult = nl.tudelft.tydi_chisel.compatCheckResult match {
+      case None       => compatCheckResult
+      case x: Some[_] => x.get
+    }
+
+    checkResult match {
       case CompatCheckResult.Error   => throw TydiStreamCompatException(problemStr)
       case CompatCheckResult.Warning => printWarning(problemStr)
     }
@@ -399,7 +404,12 @@ sealed abstract class PhysicalStreamBase(private val e: TydiEl, val n: Int, val 
     typeCheck: CompatCheck.Value,
     compatCheckResult: CompatCheckResult.Value
   ): Unit = {
-    if (typeCheck == CompatCheck.Strict) {
+    val check = nl.tudelft.tydi_chisel.compatCheck match {
+      case None       => typeCheck
+      case x: Some[_] => x.get
+    }
+
+    if (check == CompatCheck.Strict) {
       if (this.getDataType.getClass != toConnect.getDataType.getClass) {
         reportProblem(
           s"Type of stream elements is not equal. ${this} has e=${this.getDataType.getClass}, ${toConnect} has e=${toConnect.getDataType.getClass}",

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/TydiUtils.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/TydiUtils.scala
@@ -192,13 +192,8 @@ class MultiProcessorGeneral(
  */
 class StreamDuplicator(val k: Int = 2, template: PhysicalStream) extends TydiModule {
   // Create a new instance so we do not need to worry about directions.
-  private val stream: PhysicalStream = PhysicalStream(
-    new BitsEl(template.elWidth.W),
-    n = template.n,
-    d = template.d,
-    c = template.c,
-    u = UInt(template.userElWidth.W)
-  )
+  private val stream: PhysicalStream =
+    PhysicalStream(template.getDataType, n = template.n, d = template.d, c = template.c, u = template.getUserType)
   val in: PhysicalStream       = IO(Flipped(stream))
   val out: Vec[PhysicalStream] = IO(Vec(k, stream))
 

--- a/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
+++ b/library/src/main/scala/nl/tudelft/tydi_chisel/package.scala
@@ -4,4 +4,20 @@ package object tydi_chisel {
   val firNoOptimizationOpts: Array[String] = Array("-disable-opt", "-disable-all-randomization", "-strip-debug-info")
   val firNormalOpts: Array[String]         = Array("-O=debug", "-disable-all-randomization", "-strip-debug-info")
   val firReleaseOpts: Array[String]        = Array("-O=release", "-disable-all-randomization", "-strip-debug-info")
+
+  private[this] var _compatCheckResult: Option[CompatCheckResult.Value] = None
+
+  def compatCheckResult: Option[CompatCheckResult.Value] = _compatCheckResult
+
+  def setCompatCheckResult(value: CompatCheckResult.Value): Unit = {
+    _compatCheckResult = Some(value)
+  }
+
+  private[this] var _compatCheck: Option[CompatCheck.Value] = None
+
+  def compatCheck: Option[CompatCheck.Value] = _compatCheck
+
+  def setCompatCheck(value: CompatCheck.Value): Unit = {
+    _compatCheck = Some(value)
+  }
 }


### PR DESCRIPTION
This PR improves upon #15 by improving the reporting.

The formatting of the text that is emitted as a warning or error has been improved. It is now more legible and includes a short stack trace for warnings as well. This makes it easier to locate problems.
It is now possible to set the default value globally for type check strictness and reporting, whilst still allowing override with implicit variables.

Finally, this PR includes a small fix for stream duplicators. Now the duplicator will use the same datatype as in the template, avoiding a mismatched type exception/warning.